### PR TITLE
Custom cert validation

### DIFF
--- a/stock/tls.go
+++ b/stock/tls.go
@@ -22,6 +22,10 @@ func TlsNode(config *Tls) node.Node {
 		Base: nodeutil.ReflectChild(&config.Config),
 		OnChild: func(p node.Node, r node.ChildRequest) (node.Node, error) {
 			switch r.Meta.Ident() {
+			case "customClientCertValidation":
+				if r.New {
+					config.Config.ClientAuth = tls.RequireAnyClientCert
+                }
 			case "ca":
 				if r.New {
 					config.Config.RootCAs = x509.NewCertPool()

--- a/stock/tls.go
+++ b/stock/tls.go
@@ -22,10 +22,6 @@ func TlsNode(config *Tls) node.Node {
 		Base: nodeutil.ReflectChild(&config.Config),
 		OnChild: func(p node.Node, r node.ChildRequest) (node.Node, error) {
 			switch r.Meta.Ident() {
-			case "customClientCertValidation":
-				if r.New {
-					config.Config.ClientAuth = tls.RequireAnyClientCert
-                }
 			case "ca":
 				if r.New {
 					config.Config.RootCAs = x509.NewCertPool()

--- a/yang/fc-stocklib.yang
+++ b/yang/fc-stocklib.yang
@@ -6,6 +6,11 @@ module fc-stocklib {
 
     grouping tls {
 
+        leaf customClientCertValidation {
+            description "Enables client cert requests and let's users validate it";
+            type boolean;
+        }
+
         leaf serverName {
             description "Name identified in certificate for this server";
             type string;

--- a/yang/fc-stocklib.yang
+++ b/yang/fc-stocklib.yang
@@ -4,13 +4,32 @@ module fc-stocklib {
     description "management of various objects on C2 library";
 	revision 0000-00-00;
 
+    typedef clientAuthType {
+        type enumeration {
+            enum NoClientCert {
+                value 0;
+            }
+            enum RequestClientCert {
+                value 1;
+            }
+            enum RequireAnyClientCert {
+                value 2;
+            }
+            enum VerifyClientCertIfGiven {
+                value 3;
+            }
+            enum RequireAndVerifyClientCert {
+                value 4;
+            }
+        }
+    }
+    
     grouping tls {
 
-        leaf customClientCertValidation {
-            description "Enables client cert requests and let's users validate it";
-            type boolean;
+        leaf clientAuth {
+            description "Client Cert Authentication";
+            type clientAuthType;
         }
-
         leaf serverName {
             description "Name identified in certificate for this server";
             type string;


### PR DESCRIPTION
Fix for https://github.com/freeconf/restconf/issues/11
This should allow us to override the behaviour of client cert checking.

Should we change the logic in tls.go to apply this even if "ca" was provided?
Should we instead set a higher level parameter instead of directly tweaking the TLS structure?