### PR TITLE
Use http reader context for base of restconf http handling context

### DIFF
--- a/server.go
+++ b/server.go
@@ -118,7 +118,7 @@ func (srv *Server) determineCompliance(r *http.Request) ComplianceOptions {
 func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	compliance := srv.determineCompliance(r)
 	fc.Debug.Printf("compliance %s", compliance)
-	ctx := context.WithValue(context.Background(), ComplianceContextKey, compliance)
+	ctx := context.WithValue(r.Context(), ComplianceContextKey, compliance)
 	if fc.DebugLogEnabled() {
 		fc.Debug.Printf("%s %s", r.Method, r.URL)
 		if r.Body != nil {


### PR DESCRIPTION
Golang http.Request offers a base Context for handling the request, which allows the handler to automatically be interrupted by http/tcp based causes.

This closes #34 