### PR TITLE
feat(RFC8525): implement yang-library submodule

### DIFF
--- a/device/gold/yang_lib.json
+++ b/device/gold/yang_lib.json
@@ -1,4 +1,19 @@
 {
+"yang-library":{
+  "module-set":[
+    {
+      "name":"all",
+      "module":[
+        {
+          "name":"bird",
+          "revision":"0",
+          "namespace":"",
+          "location":"bird"},
+        {
+          "name":"ietf-yang-library",
+          "revision":"2019-01-04",
+          "namespace":"urn:ietf:params:xml:ns:yang:ietf-yang-library",
+          "location":"ietf-yang-library"}]}]},
 "modules-state":{
   "module":[
     {

--- a/device/yang_lib_node.go
+++ b/device/yang_lib_node.go
@@ -10,7 +10,7 @@ import (
 	"github.com/freeconf/yang/val"
 )
 
-// Implementation of RFC7895
+// Implementation of RFC8525
 
 // Export device by it's address so protocol server can serve a device
 // often referred to northbound
@@ -22,6 +22,8 @@ func LocalDeviceYangLibNode(addresser ModuleAddresser, d Device) node.Node {
 			switch r.Meta.Ident() {
 			case "modules-state":
 				return localYangLibModuleState(addresser, d), nil
+			case "yang-library":
+				return localYangLibYangLibrary(addresser, d), nil
 			}
 			return nil, nil
 		},
@@ -98,4 +100,146 @@ func yangLibModuleHandleNode(addresser ModuleAddresser, m *meta.Module) node.Nod
 			return nil
 		},
 	}
+}
+
+func localYangLibYangLibrary(addresser ModuleAddresser, d Device) node.Node {
+	mods := d.Modules()
+	modset := ModuleSet{ident: "all", module: mods}
+	modsets := make(map[string]*ModuleSet)
+	modsets["all"] = &modset
+	return &nodeutil.Basic{
+		OnChild: func(r node.ChildRequest) (node.Node, error) {
+			switch r.Meta.Ident() {
+			case "module-set":
+				return YangLibModuleSetList(addresser, modsets), nil
+			}
+			return nil, nil
+		},
+		OnField: func(r node.FieldRequest, hnd *node.ValueHandle) error {
+			return nil
+		},
+	}
+}
+
+func YangLibModuleSetList(addresser ModuleAddresser, modsets map[string]*ModuleSet) node.Node {
+	index := node.NewIndex(modsets)
+	index.Sort(func(a, b reflect.Value) bool {
+		return strings.Compare(a.String(), b.String()) < 0
+	})
+	return &nodeutil.Basic{
+		OnNext: func(r node.ListRequest) (node.Node, []val.Value, error) {
+			key := r.Key
+			var ms *ModuleSet
+			if r.Key != nil {
+				ms = modsets[r.Key[0].String()]
+			} else {
+				if v := index.NextKey(r.Row); v != node.NO_VALUE {
+					module := v.String()
+					if ms = modsets[module]; ms != nil {
+						key = []val.Value{val.String(ms.Ident())}
+					}
+				}
+			}
+			if ms != nil {
+				return yangLibModuleSetHandleNode(addresser, ms), key, nil
+			}
+			return nil, nil, nil
+		},
+	}
+}
+
+func yangLibModuleSetHandleNode(addresser ModuleAddresser, ms *ModuleSet) node.Node {
+	return &nodeutil.Basic{
+		OnChild: func(r node.ChildRequest) (node.Node, error) {
+			switch r.Meta.Ident() {
+			case "module":
+				mods := ms.Module()
+				if len(mods) > 0 {
+					return YangLibModuleSetModuleList(addresser, mods), nil
+				}
+			case "import-only-module":
+				mods := ms.ImportOnlyModule()
+				if len(mods) > 0 {
+					return YangLibModuleSetModuleList(addresser, mods), nil
+				}
+			}
+			return nil, nil
+		},
+		OnField: func(r node.FieldRequest, hnd *node.ValueHandle) error {
+			switch r.Meta.Ident() {
+			case "name":
+				hnd.Val = val.String(ms.Ident())
+			}
+			return nil
+		},
+	}
+}
+
+func YangLibModuleSetModuleList(addresser ModuleAddresser, mods map[string]*meta.Module) node.Node {
+	index := node.NewIndex(mods)
+	index.Sort(func(a, b reflect.Value) bool {
+		return strings.Compare(a.String(), b.String()) < 0
+	})
+	return &nodeutil.Basic{
+		OnNext: func(r node.ListRequest) (node.Node, []val.Value, error) {
+			key := r.Key
+			var m *meta.Module
+			if r.Key != nil {
+				m = mods[r.Key[0].String()]
+			} else {
+				if v := index.NextKey(r.Row); v != node.NO_VALUE {
+					module := v.String()
+					if m = mods[module]; m != nil {
+						key = []val.Value{val.String(m.Ident())}
+					}
+				}
+			}
+			if m != nil {
+				return yangLibModuleSetModuleHandleNode(addresser, m), key, nil
+			}
+			return nil, nil, nil
+		},
+	}
+}
+
+func yangLibModuleSetModuleHandleNode(addresser ModuleAddresser, m *meta.Module) node.Node {
+	return &nodeutil.Basic{
+		OnChild: func(r node.ChildRequest) (node.Node, error) {
+			// submodule
+			return nil, nil
+		},
+		OnField: func(r node.FieldRequest, hnd *node.ValueHandle) error {
+			switch r.Meta.Ident() {
+			case "name":
+				hnd.Val = val.String(m.Ident())
+			case "revision":
+				if m.Revision() != nil {
+					hnd.Val = val.String(m.Revision().Ident())
+				}
+			case "namespace":
+				hnd.Val = val.String(m.Namespace())
+			case "location":
+				hnd.Val = val.String(addresser(m))
+			case "feature":
+			}
+			return nil
+		},
+	}
+}
+
+type ModuleSet struct {
+	ident            string
+	module           map[string]*meta.Module
+	importOnlyModule map[string]*meta.Module
+}
+
+func (ms *ModuleSet) Ident() string {
+	return ms.ident
+}
+
+func (ms *ModuleSet) Module() map[string]*meta.Module {
+	return ms.module
+}
+func (ms *ModuleSet) ImportOnlyModule() map[string]*meta.Module {
+	return ms.importOnlyModule
 }

--- a/device/yang_lib_node.go
+++ b/device/yang_lib_node.go
@@ -104,8 +104,8 @@ func yangLibModuleHandleNode(addresser ModuleAddresser, m *meta.Module) node.Nod
 
 func localYangLibYangLibrary(addresser ModuleAddresser, d Device) node.Node {
 	mods := d.Modules()
-	modset := ModuleSet{ident: "all", module: mods}
-	modsets := make(map[string]*ModuleSet)
+	modset := moduleSet{ident: "all", module: mods}
+	modsets := make(map[string]*moduleSet)
 	modsets["all"] = &modset
 	return &nodeutil.Basic{
 		OnChild: func(r node.ChildRequest) (node.Node, error) {
@@ -121,7 +121,7 @@ func localYangLibYangLibrary(addresser ModuleAddresser, d Device) node.Node {
 	}
 }
 
-func YangLibModuleSetList(addresser ModuleAddresser, modsets map[string]*ModuleSet) node.Node {
+func YangLibModuleSetList(addresser ModuleAddresser, modsets map[string]*moduleSet) node.Node {
 	index := node.NewIndex(modsets)
 	index.Sort(func(a, b reflect.Value) bool {
 		return strings.Compare(a.String(), b.String()) < 0
@@ -129,7 +129,7 @@ func YangLibModuleSetList(addresser ModuleAddresser, modsets map[string]*ModuleS
 	return &nodeutil.Basic{
 		OnNext: func(r node.ListRequest) (node.Node, []val.Value, error) {
 			key := r.Key
-			var ms *ModuleSet
+			var ms *moduleSet
 			if r.Key != nil {
 				ms = modsets[r.Key[0].String()]
 			} else {
@@ -148,7 +148,7 @@ func YangLibModuleSetList(addresser ModuleAddresser, modsets map[string]*ModuleS
 	}
 }
 
-func yangLibModuleSetHandleNode(addresser ModuleAddresser, ms *ModuleSet) node.Node {
+func yangLibModuleSetHandleNode(addresser ModuleAddresser, ms *moduleSet) node.Node {
 	return &nodeutil.Basic{
 		OnChild: func(r node.ChildRequest) (node.Node, error) {
 			switch r.Meta.Ident() {
@@ -227,19 +227,19 @@ func yangLibModuleSetModuleHandleNode(addresser ModuleAddresser, m *meta.Module)
 	}
 }
 
-type ModuleSet struct {
+type moduleSet struct {
 	ident            string
 	module           map[string]*meta.Module
 	importOnlyModule map[string]*meta.Module
 }
 
-func (ms *ModuleSet) Ident() string {
+func (ms *moduleSet) Ident() string {
 	return ms.ident
 }
 
-func (ms *ModuleSet) Module() map[string]*meta.Module {
+func (ms *moduleSet) Module() map[string]*meta.Module {
 	return ms.module
 }
-func (ms *ModuleSet) ImportOnlyModule() map[string]*meta.Module {
+func (ms *moduleSet) ImportOnlyModule() map[string]*meta.Module {
 	return ms.importOnlyModule
 }


### PR DESCRIPTION
This PR addresses [RFC 8525](https://datatracker.ietf.org/doc/html/rfc8525) and specifically implements the `yang-library` submodule (that obsoletes the `module-state` submodule).

Closes #60 