### PR TITLE
fix: correct response to .well-known/host-meta (RFC 7033)

### DIFF
--- a/server.go
+++ b/server.go
@@ -380,7 +380,8 @@ func (srv *Server) serveStaticRoute(w http.ResponseWriter, r *http.Request) bool
 	switch op {
 	case "host-meta":
 		// RESTCONF Sec. 3.1
-		fmt.Fprintf(w, `{ "xrd" : { "link" : { "@rel" : "restconf", "@href" : "/restconf" } } }`)
+		u, _ := url.Parse("/")
+		fmt.Fprintf(w, `{ "subject": "%s", "links" : [ { "rel" : "restconf", "href" : "/restconf" } ] }`, r.URL.ResolveReference(u))
 		return true
 	}
 	return false

--- a/server.go
+++ b/server.go
@@ -379,6 +379,8 @@ func (srv *Server) serveStaticRoute(w http.ResponseWriter, r *http.Request) bool
 	op, _ := shift(p, '/')
 	switch op {
 	case "host-meta":
+		fallthrough
+	case "host-meta.json":
 		// RESTCONF Sec. 3.1
 		u, _ := url.Parse("/")
 		fmt.Fprintf(w, `{ "subject": "%s", "links" : [ { "rel" : "restconf", "href" : "/restconf" } ] }`, r.URL.ResolveReference(u))

--- a/testdata/gold/well-known
+++ b/testdata/gold/well-known
@@ -1,1 +1,1 @@
-{ "xrd" : { "link" : { "@rel" : "restconf", "@href" : "/restconf" } } }
+{ "subject": "/", "links" : [ { "rel" : "restconf", "href" : "/restconf" } ] }


### PR DESCRIPTION
Hi @dhubler,

While interacting with the FreeCONF server, we noted some issues in the response to `/.well-known/host-meta`. Specifically, it did not meet the specification of [RFC 7033](https://datatracker.ietf.org/doc/html/rfc7033#section-4.4):
- incorrect top-level object `xrd`
- missing required `subject` member
- incorrect definition of `links` (should be an array with members)
- incorrect `@` in keys

See also https://www.packetizer.com/json/jrd/ and the example in https://www.rfc-editor.org/rfc/rfc6415#appendix-A.

Please consider this PR :)