### PR TITLE
fix: harden server error handling

### DIFF
--- a/server.go
+++ b/server.go
@@ -175,8 +175,9 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(srv.Ver))
 		return
 	case ".well-known":
-		srv.serveStaticRoute(w, r)
-		return
+		if srv.serveStaticRoute(w, r) {
+			return
+		}
 	case "restconf":
 		op2, p := shift(p, '/')
 		r.URL = p

--- a/util.go
+++ b/util.go
@@ -3,6 +3,7 @@ package restconf
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -76,7 +77,12 @@ func handleErr(compliance ComplianceOptions, err error, r *http.Request, w http.
 	}
 	fc.Debug.Printf("web request error [%s] %s %s", r.Method, r.URL, err.Error())
 	msg := err.Error()
-	code := fc.HttpStatusCode(err)
+	var code int
+	if errors.Is(err, ErrBadAddress) {
+		code = 400
+	} else {
+		code = fc.HttpStatusCode(err)
+	}
 	if !compliance.SimpleErrorResponse {
 		errResp := errResponse{
 			Type:    "protocol",


### PR DESCRIPTION
 - Return error on improper /.well-known/* request
 - Return 400 code instead of 500 on improper /restconf/* resources request